### PR TITLE
Add python3-pip dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+genesis-metapackages (0.6) UNRELEASED; urgency=medium
+
+  * genesis-dev: also depend on python3-pip
+
+ -- Marti Bolivar <marti.bolivar@linaro.org>  Mon, 24 Jul 2017 15:13:13 -0400
+
 genesis-metapackages (0.5) xenial; urgency=medium
 
   * genesis-dev: add dependencies for imgtool.py

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-genesis-metapackages (0.6) UNRELEASED; urgency=medium
+genesis-metapackages (0.6) xenial; urgency=medium
 
   * genesis-dev: also depend on python3-pip
 

--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Depends: bzip2,
          python3-crypto,
          python3-ecdsa,
          python3-pyasn1,
+         python3-pip,
          repo,
          sudo,
          ${misc:Depends}


### PR DESCRIPTION
Needed to also install some packages via pip3 in genesis-sdk-container.