### PR TITLE
Add dtc dependency to genesis-metapackages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+genesis-metapackages (0.7) UNRELEASED; urgency=medium
+
+  * genesis-dev: also depend on device-tree-compiler
+
+ -- Marti Bolivar <marti.bolivar@linaro.org>  Mon, 24 Jul 2017 15:13:13 -0400
+
 genesis-metapackages (0.6) xenial; urgency=medium
 
   * genesis-dev: also depend on python3-pip

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-genesis-metapackages (0.7) UNRELEASED; urgency=medium
+genesis-metapackages (0.7) xenial; urgency=medium
 
   * genesis-dev: also depend on device-tree-compiler
 

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Vcs-Browser: https://github.com/linaro-technologies/genesis-metapackages
 Package: genesis-dev
 Architecture: all
 Depends: bzip2,
+         device-tree-compiler,
          git,
          gcc,
          gcc-multilib,


### PR DESCRIPTION
Enablement patch for prebuilt repository with gcc-arm-embedded.